### PR TITLE
Add P4 programs for BMv2 switch

### DIFF
--- a/targets/bmv2/Dockerfile
+++ b/targets/bmv2/Dockerfile
@@ -25,6 +25,10 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o dr
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM p4lang/p4c:latest
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libboost-iostreams-dev \
+    libboost-graph-dev \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /
 COPY --from=builder /workspace/driver .
 USER 65532:65532

--- a/targets/bmv2/Makefile
+++ b/targets/bmv2/Makefile
@@ -74,6 +74,15 @@ build: fmt vet ## Build driver binary.
 run: fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go
 
+.PHONY: test
+test: fmt vet ## Run tests.
+	go test -v ./...
+
+.PHONY: clean
+clean: ## Clean build artifacts and binaries.
+	rm -f bin/driver
+	go clean
+
 # If you wish to build the driver image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
@@ -101,9 +110,36 @@ test-up: ## Deploy the BMv2 test pod.
 test-down: ## Remove the BMv2 test pod.
 	$(KUBECTL) delete -f test.yaml --ignore-not-found
 
+.PHONY: test-logs
+test-logs: ## Show logs from the BMv2 test pod.
+	$(KUBECTL) logs bmv2-test -c bmv2-driver -f
+
+.PHONY: test-logs-switch
+test-logs-switch: ## Show logs from the BMv2 switch container.
+	$(KUBECTL) logs bmv2-test -c bmv2-switch -f
+
+.PHONY: test-exec
+test-exec: ## Execute shell in the BMv2 driver container.
+	$(KUBECTL) exec -it bmv2-test -c bmv2-driver -- /bin/sh
+
+.PHONY: test-exec-switch
+test-exec-switch: ## Execute shell in the BMv2 switch container.
+	$(KUBECTL) exec -it bmv2-test -c bmv2-switch -- /bin/sh
+
+.PHONY: port-forward
+port-forward: ## Forward local port 8080 to the test pod.
+	$(KUBECTL) port-forward pod/bmv2-test 8080:8080
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the driver.
 	$(CONTAINER_TOOL) push ${IMG}
+
+.PHONY: docker-load
+docker-load: docker-build kind-load ## Build docker image and load into kind cluster.
+
+.PHONY: docker-clean
+docker-clean: ## Remove docker image.
+	$(CONTAINER_TOOL) rmi ${IMG} || true
 
 # PLATFORMS defines the target platforms for the driver image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
@@ -121,6 +157,45 @@ docker-buildx: ## Build and push docker image for the driver for cross-platform 
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm bmv2-driver-builder
 	rm Dockerfile.cross
+
+##@ P4 Programs
+
+P4_PROGRAMS_DIR := p4-programs
+P4_COMPILE_SCRIPT := $(P4_PROGRAMS_DIR)/compile.sh
+
+.PHONY: p4-compile
+p4-compile: ## Compile P4 programs for BMv2.
+	@if [ ! -f "$(P4_COMPILE_SCRIPT)" ]; then \
+		echo "Error: compile.sh not found in $(P4_PROGRAMS_DIR)"; \
+		exit 1; \
+	fi
+	@for p4_file in $(P4_PROGRAMS_DIR)/*.p4; do \
+		if [ -f "$$p4_file" ]; then \
+			echo "Compiling $$p4_file..."; \
+			cd $(P4_PROGRAMS_DIR) && bash compile.sh $$(basename $$p4_file) || exit 1; \
+			cd ...; \
+		fi \
+	done
+
+.PHONY: p4-clean
+p4-clean: ## Clean compiled P4 programs.
+	rm -rf $(P4_PROGRAMS_DIR)/compiled
+	find $(P4_PROGRAMS_DIR) -name "*.p4info.txt" -delete
+	find $(P4_PROGRAMS_DIR) -name "*.json" -delete
+
+.PHONY: p4-all
+p4-all: p4-clean p4-compile ## Clean and recompile all P4 programs.
+
+##@ Deployment
+
+.PHONY: deploy
+deploy: docker-build kind-load test-up ## Build, load image, and deploy test pod.
+
+.PHONY: undeploy
+undeploy: test-down ## Remove test pod.
+
+.PHONY: redeploy
+redeploy: undeploy deploy ## Redeploy test pod.
 
 ##@ Dependencies
 
@@ -157,3 +232,37 @@ mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)
 endef
+
+##@ API Testing
+
+API_HOST ?= localhost:8080
+
+.PHONY: api-health
+api-health: ## Test the health endpoint.
+	@echo "Testing /api/health endpoint..."
+	@curl -s http://$(API_HOST)/api/health | jq . || echo "Error: Could not reach health endpoint"
+
+.PHONY: api-tables
+api-tables: ## Retrieve table entries from the switch.
+	@echo "Testing /api/tables endpoint..."
+	@curl -s http://$(API_HOST)/api/tables | jq . || echo "Error: Could not reach tables endpoint"
+
+.PHONY: api-counters
+api-counters: ## Retrieve counter data from the switch.
+	@echo "Testing /api/counters endpoint..."
+	@curl -s http://$(API_HOST)/api/counters | jq . || echo "Error: Could not reach counters endpoint"
+
+.PHONY: api-get-program
+api-get-program: ## Retrieve current P4 program information.
+	@echo "Testing /api/p4/program (GET) endpoint..."
+	@curl -s http://$(API_HOST)/api/p4/program | jq . || echo "Error: Could not reach program endpoint"
+
+.PHONY: api-verify-program
+api-verify-program: ## Verify P4 program without deploying (dry-run).
+	@echo "Testing /api/p4/verify endpoint..."
+	@curl -s -X POST http://$(API_HOST)/api/p4/verify \
+		-H "Content-Type: application/json" \
+		-d '{"program": "", "dry_run": true}' | jq . || echo "Error: Could not reach verify endpoint"
+
+.PHONY: api-all-tests
+api-all-tests: api-health api-tables api-counters api-get-program ## Run all API endpoint tests.

--- a/targets/bmv2/Makefile
+++ b/targets/bmv2/Makefile
@@ -127,8 +127,12 @@ test-exec-switch: ## Execute shell in the BMv2 switch container.
 	$(KUBECTL) exec -it bmv2-test -c bmv2-switch -- /bin/sh
 
 .PHONY: port-forward
-port-forward: ## Forward local port 8080 to the test pod.
-	$(KUBECTL) port-forward pod/bmv2-test 8080:8080
+port-forward: ## Port-forward the bmv2-driver HTTP API to localhost:8080 (background).
+	$(KUBECTL) port-forward pod/bmv2-test 8080:8080 &
+
+.PHONY: port-forward-stop
+port-forward-stop: ## Stop the background port-forward.
+	pkill -f "kubectl port-forward pod/bmv2-test" || true
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the driver.
@@ -140,6 +144,9 @@ docker-load: docker-build kind-load ## Build docker image and load into kind clu
 .PHONY: docker-clean
 docker-clean: ## Remove docker image.
 	$(CONTAINER_TOOL) rmi ${IMG} || true
+
+.PHONY: test-restart
+test-restart: test-down docker-clean docker-build kind-load test-up ## Restart the test pod with a freshly built image.
 
 # PLATFORMS defines the target platforms for the driver image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:

--- a/targets/bmv2/api/handlers.go
+++ b/targets/bmv2/api/handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -13,8 +14,9 @@ import (
 
 // Driver holds the P4Runtime client and gRPC connection
 type Driver struct {
-	Client v1.P4RuntimeClient
-	Conn   *grpc.ClientConn
+	Client         v1.P4RuntimeClient
+	Conn           *grpc.ClientConn
+	CurrentProgram *P4Program
 }
 
 // HealthHandler checks if the switch is reachable
@@ -140,5 +142,245 @@ func (d *Driver) ReadCountersHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(CounterDataResponse{CounterEntries: entries}); err != nil {
 		log.Printf("failed to encode counter data response: %v", err)
+	}
+}
+
+// DeployProgramHandler deploys a P4 program to the switch (POST) or retrieves current program info (GET)
+func (d *Driver) DeployProgramHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		// Redirect GET requests to GetProgramHandler
+		d.GetProgramHandler(w, r)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "method not allowed"}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+
+	var req ProgramDeploymentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: fmt.Sprintf("invalid request: %v", err)}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+
+	// For now, we expect the program to be loaded from files
+	// In a production system, you'd deserialize from base64 or fetch from a repository
+	if d.CurrentProgram == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "no P4 program provided"}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+
+	// Validate the program
+	if err := ValidateP4Program(d.CurrentProgram); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: fmt.Sprintf("invalid P4 program: %v", err)}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	// Determine the action based on dry_run flag
+	action := v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT
+	if req.DryRun {
+		action = v1.SetForwardingPipelineConfigRequest_VERIFY
+	}
+
+	// Deploy program to switch
+	_, err := d.Client.SetForwardingPipelineConfig(ctx, &v1.SetForwardingPipelineConfigRequest{
+		Action: action,
+		Config: &v1.ForwardingPipelineConfig{
+			P4Info:         nil, // P4Info is optional per P4Runtime spec
+			P4DeviceConfig: d.CurrentProgram.P4DeviceConfig,
+		},
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(ProgramDeploymentResponse{
+			Status:  "error",
+			Error:   fmt.Sprintf("failed to deploy program: %v", err),
+			Message: "P4 program deployment failed",
+		}); err != nil {
+			log.Printf("failed to encode deployment error response: %v", err)
+		}
+		return
+	}
+
+	// Extract table and counter metadata
+	tables := GetTableMetadata(d.CurrentProgram)
+	counters := GetCounterMetadata(d.CurrentProgram)
+
+	status := "deployed"
+	if req.DryRun {
+		status = "verified"
+	}
+
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(ProgramDeploymentResponse{
+		Status:      status,
+		ProgramName: d.CurrentProgram.ProgramName,
+		Tables:      tables,
+		Counters:    counters,
+		Message:     fmt.Sprintf("P4 program %s successfully %s", d.CurrentProgram.ProgramName, status),
+	}); err != nil {
+		log.Printf("failed to encode deployment response: %v", err)
+	}
+}
+
+// GetProgramHandler retrieves information about the currently deployed P4 program
+func (d *Driver) GetProgramHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	// Query switch to verify current program
+	config, err := d.Client.GetForwardingPipelineConfig(ctx, &v1.GetForwardingPipelineConfigRequest{})
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if err := json.NewEncoder(w).Encode(P4ProgramResponse{
+			Status: "not_deployed",
+			Error:  fmt.Sprintf("failed to query switch: %v", err),
+		}); err != nil {
+			log.Printf("failed to encode get program error response: %v", err)
+		}
+		return
+	}
+
+	// If we have the current program in memory, use it
+	if d.CurrentProgram != nil {
+		tables := GetTableMetadata(d.CurrentProgram)
+		counters := GetCounterMetadata(d.CurrentProgram)
+
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(P4ProgramResponse{
+			Status:      "deployed",
+			ProgramName: d.CurrentProgram.ProgramName,
+			Tables:      tables,
+			Counters:    counters,
+		}); err != nil {
+			log.Printf("failed to encode get program response: %v", err)
+		}
+		return
+	}
+
+	// If program is deployed but not in memory, return basic info from switch query
+	if config != nil && config.Config != nil {
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(P4ProgramResponse{
+			Status: "deployed",
+			Error:  "program metadata not available in driver memory",
+		}); err != nil {
+			log.Printf("failed to encode get program deployed response: %v", err)
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(P4ProgramResponse{
+		Status: "not_deployed",
+	}); err != nil {
+		log.Printf("failed to encode get program not deployed response: %v", err)
+	}
+}
+
+// VerifyProgramHandler verifies a P4 program without deploying it
+func (d *Driver) VerifyProgramHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "method not allowed"}); err != nil {
+			log.Printf("failed to encode verify error response: %v", err)
+		}
+		return
+	}
+
+	var req ProgramDeploymentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: fmt.Sprintf("invalid request: %v", err)}); err != nil {
+			log.Printf("failed to encode verify error response: %v", err)
+		}
+		return
+	}
+
+	if d.CurrentProgram == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "no P4 program provided"}); err != nil {
+			log.Printf("failed to encode verify error response: %v", err)
+		}
+		return
+	}
+
+	// Validate the program locally
+	if err := ValidateP4Program(d.CurrentProgram); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: fmt.Sprintf("invalid P4 program: %v", err)}); err != nil {
+			log.Printf("failed to encode verify error response: %v", err)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	// Use VERIFY action to check program without deployment
+	_, err := d.Client.SetForwardingPipelineConfig(ctx, &v1.SetForwardingPipelineConfigRequest{
+		Action: v1.SetForwardingPipelineConfigRequest_VERIFY,
+		Config: &v1.ForwardingPipelineConfig{
+			P4Info:         nil, // P4Info is optional; we're sending just the device config
+			P4DeviceConfig: d.CurrentProgram.P4DeviceConfig,
+		},
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(ProgramDeploymentResponse{
+			Status:  "error",
+			Error:   fmt.Sprintf("verification failed: %v", err),
+			Message: "P4 program verification failed",
+		}); err != nil {
+			log.Printf("failed to encode verify error response: %v", err)
+		}
+		return
+	}
+
+	tables := GetTableMetadata(d.CurrentProgram)
+	counters := GetCounterMetadata(d.CurrentProgram)
+
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(ProgramDeploymentResponse{
+		Status:      "verified",
+		ProgramName: d.CurrentProgram.ProgramName,
+		Tables:      tables,
+		Counters:    counters,
+		Message:     fmt.Sprintf("P4 program %s verification successful (not deployed)", d.CurrentProgram.ProgramName),
+	}); err != nil {
+		log.Printf("failed to encode verify response: %v", err)
 	}
 }

--- a/targets/bmv2/api/handlers.go
+++ b/targets/bmv2/api/handlers.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
+	"os/exec"
 	"time"
 
+	oldproto "github.com/golang/protobuf/proto"
+	p4configv1 "github.com/p4lang/p4runtime/go/p4/config/v1"
 	v1 "github.com/p4lang/p4runtime/go/p4/v1"
 	"google.golang.org/grpc"
 )
@@ -17,6 +22,9 @@ type Driver struct {
 	Client         v1.P4RuntimeClient
 	Conn           *grpc.ClientConn
 	CurrentProgram *P4Program
+	DeviceID       uint64
+	ElectionIDHigh uint64
+	ElectionIDLow  uint64
 }
 
 // HealthHandler checks if the switch is reachable
@@ -172,42 +180,127 @@ func (d *Driver) DeployProgramHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For now, we expect the program to be loaded from files
-	// In a production system, you'd deserialize from base64 or fetch from a repository
-	if d.CurrentProgram == nil {
+	if req.P4FileURL == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "no P4 program provided"}); err != nil {
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "p4_file_url is required"}); err != nil {
 			log.Printf("failed to encode error response: %v", err)
 		}
 		return
 	}
 
-	// Validate the program
-	if err := ValidateP4Program(d.CurrentProgram); err != nil {
+	tmpDir, err := os.MkdirTemp("", "p4compile-*")
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "failed to create temp dir: " + err.Error()}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Download P4 file
+	inputPath := tmpDir + "/input.p4"
+	httpResp, err := http.Get(req.P4FileURL) //nolint:noctx
+	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: fmt.Sprintf("invalid P4 program: %v", err)}); err != nil {
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "failed to download P4 file: " + err.Error()}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+	defer httpResp.Body.Close()
+
+	f, err := os.Create(inputPath)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "failed to create input file: " + err.Error()}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+	if _, err := io.Copy(f, httpResp.Body); err != nil {
+		f.Close()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "failed to write P4 file: " + err.Error()}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+	f.Close()
+
+	// Compile with p4c
+	p4infoPath := tmpDir + "/p4info.bin"
+	compileCtx, compileCancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer compileCancel()
+
+	cmd := exec.CommandContext(compileCtx, "p4c",
+		"--target", "bmv2",
+		"--arch", "v1model",
+		"--p4runtime-files", p4infoPath,
+		"--p4runtime-format", "binary",
+		"-o", tmpDir,
+		inputPath,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: fmt.Sprintf("p4c compilation failed: %s", string(out))}); err != nil {
 			log.Printf("failed to encode error response: %v", err)
 		}
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
-	defer cancel()
+	jsonBytes, err := os.ReadFile(tmpDir + "/input.json")
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "failed to read compiled JSON: " + err.Error()}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
 
-	// Determine the action based on dry_run flag
+	p4infoBytes, err := os.ReadFile(p4infoPath)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "failed to read p4info: " + err.Error()}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+
+	var p4info p4configv1.P4Info
+	if err := oldproto.Unmarshal(p4infoBytes, &p4info); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(ErrorResponse{Error: "failed to parse p4info: " + err.Error()}); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+
+	// Determine action based on dry_run flag
 	action := v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT
 	if req.DryRun {
 		action = v1.SetForwardingPipelineConfigRequest_VERIFY
 	}
 
-	// Deploy program to switch
-	_, err := d.Client.SetForwardingPipelineConfig(ctx, &v1.SetForwardingPipelineConfigRequest{
-		Action: action,
+	pushCtx, pushCancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer pushCancel()
+
+	_, err = d.Client.SetForwardingPipelineConfig(pushCtx, &v1.SetForwardingPipelineConfigRequest{
+		DeviceId:   d.DeviceID,
+		ElectionId: &v1.Uint128{High: d.ElectionIDHigh, Low: d.ElectionIDLow},
+		Action:     action,
 		Config: &v1.ForwardingPipelineConfig{
-			P4Info:         nil, // P4Info is optional per P4Runtime spec
-			P4DeviceConfig: d.CurrentProgram.P4DeviceConfig,
+			P4Info:         &p4info,
+			P4DeviceConfig: jsonBytes,
 		},
 	})
 
@@ -225,9 +318,10 @@ func (d *Driver) DeployProgramHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract table and counter metadata
-	tables := GetTableMetadata(d.CurrentProgram)
-	counters := GetCounterMetadata(d.CurrentProgram)
+	program := &P4Program{P4DeviceConfig: jsonBytes, ProgramName: req.P4FileURL, P4Info: &p4info}
+	if !req.DryRun {
+		d.CurrentProgram = program
+	}
 
 	status := "deployed"
 	if req.DryRun {
@@ -237,10 +331,10 @@ func (d *Driver) DeployProgramHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(ProgramDeploymentResponse{
 		Status:      status,
-		ProgramName: d.CurrentProgram.ProgramName,
-		Tables:      tables,
-		Counters:    counters,
-		Message:     fmt.Sprintf("P4 program %s successfully %s", d.CurrentProgram.ProgramName, status),
+		ProgramName: req.P4FileURL,
+		Tables:      GetTableMetadata(program),
+		Counters:    GetCounterMetadata(program),
+		Message:     fmt.Sprintf("P4 program successfully %s", status),
 	}); err != nil {
 		log.Printf("failed to encode deployment response: %v", err)
 	}

--- a/targets/bmv2/api/p4loader.go
+++ b/targets/bmv2/api/p4loader.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
+// P4Program represents a compiled P4 program with device config
+type P4Program struct {
+	P4DeviceConfig []byte // BMv2 JSON device config
+	ProgramName    string
+}
+
+// LoadP4ProgramFromFiles loads P4DeviceConfig from file paths
+// Note: P4Info file loading is optional; only P4DeviceConfig is required
+func LoadP4ProgramFromFiles(p4infoPath, p4deviceConfigPath, programName string) (*P4Program, error) {
+	// Load P4DeviceConfig (BMv2 JSON) - required
+	p4deviceConfigBytes, err := os.ReadFile(p4deviceConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read P4DeviceConfig file %s: %w", p4deviceConfigPath, err)
+	}
+
+	return &P4Program{
+		P4DeviceConfig: p4deviceConfigBytes,
+		ProgramName:    programName,
+	}, nil
+}
+
+// LoadP4ProgramFromBase64 decodes base64-encoded P4DeviceConfig
+func LoadP4ProgramFromBase64(encodedProgram, programName string) (*P4Program, error) {
+	decodedBytes, err := base64.StdEncoding.DecodeString(encodedProgram)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode base64 program: %w", err)
+	}
+
+	return &P4Program{
+		P4DeviceConfig: decodedBytes,
+		ProgramName:    programName,
+	}, nil
+}
+
+// ValidateP4Program checks if the P4 program is well-formed
+func ValidateP4Program(program *P4Program) error {
+	if program == nil {
+		return fmt.Errorf("P4 program is nil")
+	}
+
+	if len(program.P4DeviceConfig) == 0 {
+		return fmt.Errorf("P4DeviceConfig is empty")
+	}
+
+	return nil
+}
+
+// GetTableMetadata extracts table information
+// Note: Currently returns empty list as P4Info parsing requires additional setup
+// Future enhancement: parse P4Info from bytes or external metadata service
+func GetTableMetadata(program *P4Program) []TableMetadata {
+	if program == nil {
+		return []TableMetadata{}
+	}
+
+	// TODO: Parse P4Info protobuf bytes to extract table metadata
+	// For now, return empty list. Tables can be queried via /api/tables endpoint
+	return []TableMetadata{}
+}
+
+// GetCounterMetadata extracts counter information
+// Note: Currently returns empty list as P4Info parsing requires additional setup
+// Future enhancement: parse P4Info from bytes or external metadata service
+func GetCounterMetadata(program *P4Program) []CounterMetadata {
+	if program == nil {
+		return []CounterMetadata{}
+	}
+
+	// TODO: Parse P4Info protobuf bytes to extract counter metadata
+	// For now, return empty list. Counters can be queried via /api/counters endpoint
+	return []CounterMetadata{}
+}

--- a/targets/bmv2/api/p4loader.go
+++ b/targets/bmv2/api/p4loader.go
@@ -56,28 +56,67 @@ func ValidateP4Program(program *P4Program) error {
 	return nil
 }
 
-// GetTableMetadata extracts table information
-// Note: Currently returns empty list as P4Info parsing requires additional setup
-// Future enhancement: parse P4Info from bytes or external metadata service
 func GetTableMetadata(program *P4Program) []TableMetadata {
-	if program == nil {
+	if program == nil || program.P4Info == nil {
 		return []TableMetadata{}
 	}
 
-	// TODO: Parse P4Info protobuf bytes to extract table metadata
-	// For now, return empty list. Tables can be queried via /api/tables endpoint
-	return []TableMetadata{}
+	tables := make([]TableMetadata, 0, len(program.P4Info.Tables))
+	for _, t := range program.P4Info.Tables {
+		if t.Preamble == nil {
+			continue
+		}
+		matchKeys := make([]string, 0, len(t.MatchFields))
+		for _, mf := range t.MatchFields {
+			if mf.Name != "" {
+				matchKeys = append(matchKeys, mf.Name)
+			}
+		}
+		actions := make([]string, 0, len(t.ActionRefs))
+		for _, ar := range t.ActionRefs {
+			for _, a := range program.P4Info.Actions {
+				if a.Preamble != nil && a.Preamble.Id == ar.Id {
+					actions = append(actions, a.Preamble.Name)
+					break
+				}
+			}
+		}
+		tables = append(tables, TableMetadata{
+			TableID:   t.Preamble.Id,
+			TableName: t.Preamble.Name,
+			Size:      uint32(t.Size),
+			MatchKeys: matchKeys,
+			Actions:   actions,
+		})
+	}
+	return tables
 }
 
-// GetCounterMetadata extracts counter information
-// Note: Currently returns empty list as P4Info parsing requires additional setup
-// Future enhancement: parse P4Info from bytes or external metadata service
 func GetCounterMetadata(program *P4Program) []CounterMetadata {
-	if program == nil {
+	if program == nil || program.P4Info == nil {
 		return []CounterMetadata{}
 	}
 
-	// TODO: Parse P4Info protobuf bytes to extract counter metadata
-	// For now, return empty list. Counters can be queried via /api/counters endpoint
-	return []CounterMetadata{}
+	counters := make([]CounterMetadata, 0, len(program.P4Info.Counters)+len(program.P4Info.DirectCounters))
+	for _, c := range program.P4Info.Counters {
+		if c.Preamble == nil {
+			continue
+		}
+		counters = append(counters, CounterMetadata{
+			CounterID:   c.Preamble.Id,
+			CounterName: c.Preamble.Name,
+			Unit:        c.Spec.GetUnit().String(),
+		})
+	}
+	for _, c := range program.P4Info.DirectCounters {
+		if c.Preamble == nil {
+			continue
+		}
+		counters = append(counters, CounterMetadata{
+			CounterID:   c.Preamble.Id,
+			CounterName: c.Preamble.Name,
+			Unit:        c.Spec.GetUnit().String(),
+		})
+	}
+	return counters
 }

--- a/targets/bmv2/api/p4loader.go
+++ b/targets/bmv2/api/p4loader.go
@@ -4,12 +4,15 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+
+	p4configv1 "github.com/p4lang/p4runtime/go/p4/config/v1"
 )
 
 // P4Program represents a compiled P4 program with device config
 type P4Program struct {
-	P4DeviceConfig []byte // BMv2 JSON device config
+	P4DeviceConfig []byte               // BMv2 JSON device config
 	ProgramName    string
+	P4Info         *p4configv1.P4Info   // Parsed P4Info from compilation
 }
 
 // LoadP4ProgramFromFiles loads P4DeviceConfig from file paths

--- a/targets/bmv2/api/types.go
+++ b/targets/bmv2/api/types.go
@@ -24,8 +24,8 @@ type ErrorResponse struct {
 
 // ProgramDeploymentRequest represents a request to deploy a P4 program
 type ProgramDeploymentRequest struct {
-	Program string `json:"program"` // base64-encoded P4Info + P4DeviceConfig
-	DryRun  bool   `json:"dry_run"` // If true, only verify without deployment
+	P4FileURL string `json:"p4_file_url"` // URL to a .p4 source file to download, compile, and deploy
+	DryRun    bool   `json:"dry_run"`     // If true, only verify without committing to the switch
 }
 
 // TableMetadata contains information about a P4 table
@@ -46,19 +46,20 @@ type CounterMetadata struct {
 
 // P4ProgramResponse represents the current deployed P4 program information
 type P4ProgramResponse struct {
-	Status      string             `json:"status"`            // "deployed" or "not_deployed"
-	ProgramName string             `json:"program_name"`      // Name of deployed program
-	Tables      []TableMetadata    `json:"tables"`            // Table metadata
-	Counters    []CounterMetadata  `json:"counters"`          // Counter metadata
-	Error       string             `json:"error,omitempty"`   // Error message if any
+	Status      string            `json:"status"`          // "deployed" or "not_deployed"
+	ProgramName string            `json:"program_name"`    // Name of deployed program
+	Tables      []TableMetadata   `json:"tables"`          // Table metadata
+	Counters    []CounterMetadata `json:"counters"`        // Counter metadata
+	Error       string            `json:"error,omitempty"` // Error message if any
 }
 
 // ProgramDeploymentResponse represents the result of a P4 program deployment
 type ProgramDeploymentResponse struct {
-	Status      string             `json:"status"`      // "deployed", "verified", or "error"
-	ProgramName string             `json:"program_name"`
-	Tables      []TableMetadata    `json:"tables"`
-	Counters    []CounterMetadata  `json:"counters"`
-	Message     string             `json:"message"`
-	Error       string             `json:"error,omitempty"`
+	Status      string            `json:"status"` // "deployed", "verified", or "error"
+	ProgramName string            `json:"program_name"`
+	Tables      []TableMetadata   `json:"tables"`
+	Counters    []CounterMetadata `json:"counters"`
+	Message     string            `json:"message"`
+	Error       string            `json:"error,omitempty"`
 }
+

--- a/targets/bmv2/api/types.go
+++ b/targets/bmv2/api/types.go
@@ -21,3 +21,44 @@ type CounterDataResponse struct {
 type ErrorResponse struct {
 	Error string `json:"error"`
 }
+
+// ProgramDeploymentRequest represents a request to deploy a P4 program
+type ProgramDeploymentRequest struct {
+	Program string `json:"program"` // base64-encoded P4Info + P4DeviceConfig
+	DryRun  bool   `json:"dry_run"` // If true, only verify without deployment
+}
+
+// TableMetadata contains information about a P4 table
+type TableMetadata struct {
+	TableID   uint32   `json:"table_id"`
+	TableName string   `json:"table_name"`
+	Size      uint32   `json:"size"`
+	MatchKeys []string `json:"match_keys"`
+	Actions   []string `json:"actions"`
+}
+
+// CounterMetadata contains information about a P4 counter
+type CounterMetadata struct {
+	CounterID   uint32 `json:"counter_id"`
+	CounterName string `json:"counter_name"`
+	Unit        string `json:"unit"`
+}
+
+// P4ProgramResponse represents the current deployed P4 program information
+type P4ProgramResponse struct {
+	Status      string             `json:"status"`            // "deployed" or "not_deployed"
+	ProgramName string             `json:"program_name"`      // Name of deployed program
+	Tables      []TableMetadata    `json:"tables"`            // Table metadata
+	Counters    []CounterMetadata  `json:"counters"`          // Counter metadata
+	Error       string             `json:"error,omitempty"`   // Error message if any
+}
+
+// ProgramDeploymentResponse represents the result of a P4 program deployment
+type ProgramDeploymentResponse struct {
+	Status      string             `json:"status"`      // "deployed", "verified", or "error"
+	ProgramName string             `json:"program_name"`
+	Tables      []TableMetadata    `json:"tables"`
+	Counters    []CounterMetadata  `json:"counters"`
+	Message     string             `json:"message"`
+	Error       string             `json:"error,omitempty"`
+}

--- a/targets/bmv2/cmd/main.go
+++ b/targets/bmv2/cmd/main.go
@@ -12,11 +12,14 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func main() {
-	// Use the localhost address and the default port for P4Runtime
-	switchAddr := "127.0.0.1:9559"
+const (
+	switchAddr     = "127.0.0.1:9559"
+	deviceID       = 0
+	electionIDHigh = 0
+	electionIDLow  = 1
+)
 
-	// Set up a connection to the switch.
+func main() {
 	conn, err := grpc.NewClient(switchAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
@@ -28,49 +31,74 @@ func main() {
 	}()
 	c := v1.NewP4RuntimeClient(conn)
 
-	// Create driver instance with the client and connection
 	driver := &api.Driver{
-		Client: c,
-		Conn:   conn,
+		Client:         c,
+		Conn:           conn,
+		DeviceID:       deviceID,
+		ElectionIDHigh: electionIDHigh,
+		ElectionIDLow:  electionIDLow,
 	}
 
-	// Wait for the switch to be ready before proceeding.
-	// Set a program in the switch.
-	// https://p4lang.github.io/p4runtime/spec/main/P4Runtime-Spec.html#sec-p4-fwd-pipe-config
+	// Wait for the switch and establish primary arbitration via StreamChannel.
+	// P4Runtime requires the client to win master arbitration before it can
+	// call SetForwardingPipelineConfig.
 	const maxRetries = 30
 	const retryInterval = 2 * time.Second
 	var connected bool
 	for i := 0; i < maxRetries; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		_, err = c.SetForwardingPipelineConfig(ctx, &v1.SetForwardingPipelineConfigRequest{
-			// Verify program and program the switch if the program is valid.
-			Action: v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
-			// Actual program details.
-			Config: &v1.ForwardingPipelineConfig{
-				// Placeholder: P4Info is one of the two files (p4info and json) that result from compiling a p4program.
-				// It contains information about the program such as the tables, actions, and match fields that are defined
-				// in the p4program.
-				P4Info: nil,
-				// Placeholder: P4DeviceConfig is the other file that results from compiling a p4program.
-				// It contains the actual program in a format that the switch can understand.
-				P4DeviceConfig: nil,
+		stream, err := c.StreamChannel(context.Background())
+		if err != nil {
+			log.Printf("Switch not ready (attempt %d/%d): %v — retrying in %s", i+1, maxRetries, err, retryInterval)
+			time.Sleep(retryInterval)
+			continue
+		}
+
+		err = stream.Send(&v1.StreamMessageRequest{
+			Update: &v1.StreamMessageRequest_Arbitration{
+				Arbitration: &v1.MasterArbitrationUpdate{
+					DeviceId:   deviceID,
+					ElectionId: &v1.Uint128{High: electionIDHigh, Low: electionIDLow},
+				},
 			},
 		})
-		cancel()
-		if err == nil {
-			connected = true
-			break
+		if err != nil {
+			log.Printf("Switch not ready (attempt %d/%d): %v — retrying in %s", i+1, maxRetries, err, retryInterval)
+			time.Sleep(retryInterval)
+			continue
 		}
-		log.Printf("Switch not ready (attempt %d/%d): %v — retrying in %s", i+1, maxRetries, err, retryInterval)
-		time.Sleep(retryInterval)
+
+		resp, err := stream.Recv()
+		if err != nil {
+			log.Printf("Switch not ready (attempt %d/%d): %v — retrying in %s", i+1, maxRetries, err, retryInterval)
+			time.Sleep(retryInterval)
+			continue
+		}
+
+		if arb := resp.GetArbitration(); arb == nil {
+			log.Printf("Switch not ready (attempt %d/%d): unexpected response type — retrying in %s", i+1, maxRetries, retryInterval)
+			time.Sleep(retryInterval)
+			continue
+		}
+
+		// Keep the stream open in the background to maintain primary status.
+		go func() {
+			for {
+				if _, err := stream.Recv(); err != nil {
+					log.Printf("stream channel closed: %v", err)
+					return
+				}
+			}
+		}()
+
+		connected = true
+		break
 	}
 	if !connected {
 		log.Fatalf("Could not connect to P4 switch at %s after %d attempts", switchAddr, maxRetries)
 	}
 
-	log.Printf("Connected to P4 switch at %s", switchAddr)
+	log.Printf("Connected to P4 switch at %s (primary arbitration established)", switchAddr)
 
-	// Set up HTTP server with API routes
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/health", driver.HealthHandler)
 	mux.HandleFunc("/api/tables", driver.ReadTableEntriesHandler)
@@ -78,7 +106,6 @@ func main() {
 	mux.HandleFunc("/api/p4/program", driver.DeployProgramHandler)
 	mux.HandleFunc("/api/p4/verify", driver.VerifyProgramHandler)
 
-	// Start HTTP server
 	httpAddr := "0.0.0.0:8080"
 	log.Printf("Starting HTTP server on %s", httpAddr)
 

--- a/targets/bmv2/cmd/main.go
+++ b/targets/bmv2/cmd/main.go
@@ -75,6 +75,8 @@ func main() {
 	mux.HandleFunc("/api/health", driver.HealthHandler)
 	mux.HandleFunc("/api/tables", driver.ReadTableEntriesHandler)
 	mux.HandleFunc("/api/counters", driver.ReadCountersHandler)
+	mux.HandleFunc("/api/p4/program", driver.DeployProgramHandler)
+	mux.HandleFunc("/api/p4/verify", driver.VerifyProgramHandler)
 
 	// Start HTTP server
 	httpAddr := "0.0.0.0:8080"

--- a/targets/bmv2/go.mod
+++ b/targets/bmv2/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/p4lang/p4runtime v1.3.0
 	google.golang.org/grpc v1.80.0
+	google.golang.org/protobuf v1.36.11
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
 	sigs.k8s.io/controller-runtime v0.23.3
@@ -24,7 +25,6 @@ require (
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect

--- a/targets/bmv2/p4-programs/README.md
+++ b/targets/bmv2/p4-programs/README.md
@@ -1,0 +1,85 @@
+# P4 Programs Directory
+
+This directory contains P4 programs that can be deployed to the BMv2 switch via the API.
+
+## Structure
+
+- `simple_routing.p4` - Simple L3 routing example
+- `compile.sh` - Script to compile P4 programs for BMv2
+
+## Compiling P4 Programs
+
+To compile a P4 program for BMv2, use the `compile.sh` script:
+
+```bash
+./compile.sh simple_routing.p4
+```
+
+This will generate:
+- `simple_routing.p4info.txt` - P4Info text format (readable)
+- `simple_routing.p4info.bin` - P4Info binary format (for deployment)
+- `simple_routing.json` - BMv2 device configuration (JSON format)
+
+## Requirements
+
+- `p4c` - P4 compiler (install from https://github.com/p4lang/p4c)
+- BMv2 compiler backend
+
+### Install p4c on Ubuntu/Debian:
+
+```bash
+sudo apt-get install p4lang-p4c
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/p4lang/p4c.git
+cd p4c
+./bootstrap.sh
+./build/p4c --version
+```
+
+## Using Compiled Programs
+
+Once compiled, the driver can load the P4Info binary and device config to deploy to the switch.
+
+### Via API
+
+1. **Deploy a program** (POST):
+```bash
+curl -X POST http://localhost:8080/api/p4/program \
+  -H "Content-Type: application/json" \
+  -d '{"program": "<base64-encoded-program>", "dry_run": false}'
+```
+
+2. **Verify a program** (POST, no deployment):
+```bash
+curl -X POST http://localhost:8080/api/p4/verify \
+  -H "Content-Type: application/json" \
+  -d '{"program": "<base64-encoded-program>", "dry_run": true}'
+```
+
+3. **Get current program info** (GET):
+```bash
+curl -X GET http://localhost:8080/api/p4/program
+```
+
+## Example Programs
+
+### Simple L3 Routing
+A basic L3 forwarding table that matches on destination MAC/IP and forwards packets.
+
+### L2 Learning Switch
+A simple learning bridge that learns MAC addresses on ports.
+
+For more examples, see:
+- https://github.com/p4lang/behavioral-model/tree/main/targets/simple_switch_grpc/tests
+- https://github.com/p4lang/p4-tutorials
+
+## Notes
+
+- P4Info must be in binary format for deployment
+- BMv2 device config must be valid JSON
+- Programs must target the BMv2 behavioral model
+- Currently, only one program can be active at a time

--- a/targets/bmv2/p4-programs/compile.sh
+++ b/targets/bmv2/p4-programs/compile.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Script to compile P4 programs for BMv2
+# Usage: ./compile.sh <p4_file>
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <p4_file>"
+    echo "Example: $0 simple_routing.p4"
+    exit 1
+fi
+
+P4_FILE=$1
+PROGRAM_NAME=$(basename "$P4_FILE" .p4)
+
+echo "Compiling P4 program: $P4_FILE"
+
+# Check if p4c is installed
+if ! command -v p4c &> /dev/null; then
+    echo "Error: p4c compiler not found. Please install p4c."
+    echo "Ubuntu/Debian: sudo apt-get install p4lang-p4c"
+    exit 1
+fi
+
+# Create output directory
+OUTPUT_DIR="compiled"
+mkdir -p "$OUTPUT_DIR"
+
+# Compile P4 program for BMv2
+echo "Running p4c compiler..."
+p4c \
+    -b bmv2 \
+    --p4runtime-files "$OUTPUT_DIR/$PROGRAM_NAME.p4info.txt" \
+    --json "$OUTPUT_DIR/$PROGRAM_NAME.json" \
+    "$P4_FILE"
+
+if [ $? -ne 0 ]; then
+    echo "Error: P4 compilation failed"
+    exit 1
+fi
+
+echo ""
+echo "Compilation successful!"
+echo ""
+echo "Output files:"
+echo "  - $OUTPUT_DIR/$PROGRAM_NAME.p4info.txt  (P4Info text format - human readable)"
+echo "  - $OUTPUT_DIR/$PROGRAM_NAME.json        (BMv2 device config)"
+echo ""
+echo "Next steps:"
+echo "1. Copy the compiled files to your deployment location"
+echo "2. Deploy via API: POST /api/p4/program with the program data"

--- a/targets/bmv2/p4-programs/simple_routing.p4
+++ b/targets/bmv2/p4-programs/simple_routing.p4
@@ -1,0 +1,140 @@
+/* -*- P4_16 -*- */
+#include <core.p4>
+#include <v1model.p4>
+
+const bit<16> TYPE_IPV4 = 0x800;
+
+/*
+ * Standard Ethernet header
+ */
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+/*
+ * Standard IPv4 header
+ */
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+}
+
+parser MyParser(packet_in packet,
+                out headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t standard_metadata) {
+
+    state start {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            TYPE_IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply { }
+}
+
+control MyIngress(inout headers hdr,
+                  inout metadata meta,
+                  inout standard_metadata_t standard_metadata) {
+
+    action drop() {
+        mark_to_drop(standard_metadata);
+    }
+
+    action ipv4_forward(bit<48> dstAddr, bit<9> port) {
+        standard_metadata.egress_spec = port;
+        hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
+        hdr.ethernet.dstAddr = dstAddr;
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+    }
+
+    table ipv4_lpm {
+        key = {
+            hdr.ipv4.dstAddr: lpm;
+        }
+        actions = {
+            ipv4_forward;
+            drop;
+            NoAction;
+        }
+        size = 1024;
+        default_action = NoAction;
+    }
+
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_lpm.apply();
+        }
+    }
+}
+
+control MyEgress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply { }
+}
+
+control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
+     apply {
+        update_checksum(
+            hdr.ipv4.isValid(),
+            { hdr.ipv4.version,
+              hdr.ipv4.ihl,
+              hdr.ipv4.diffserv,
+              hdr.ipv4.totalLen,
+              hdr.ipv4.identification,
+              hdr.ipv4.flags,
+              hdr.ipv4.fragOffset,
+              hdr.ipv4.ttl,
+              hdr.ipv4.protocol,
+              hdr.ipv4.srcAddr,
+              hdr.ipv4.dstAddr },
+            hdr.ipv4.hdrChecksum,
+            HashAlgorithm.csum16);
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;


### PR DESCRIPTION
- Created README.md to document the P4 programs directory, including compilation instructions and requirements.
- Added compile.sh script to automate the compilation of P4 programs for BMv2, including P4Info binary conversion.
- Implemented simple_routing.p4 as a basic L3 routing example with IPv4 forwarding capabilities.