### PR TITLE
Bmv2target nf managers

### DIFF
--- a/targets/bmv2/Makefile
+++ b/targets/bmv2/Makefile
@@ -128,7 +128,7 @@ test-exec-switch: ## Execute shell in the BMv2 switch container.
 
 .PHONY: port-forward
 port-forward: ## Port-forward the bmv2-driver HTTP API to localhost:8080 (background).
-	$(KUBECTL) port-forward pod/bmv2-test 8080:8082 &
+	$(KUBECTL) port-forward pod/bmv2-test 8080:8080 &
 
 .PHONY: port-forward-stop
 port-forward-stop: ## Stop the background port-forward.
@@ -269,7 +269,7 @@ api-verify-program: ## Verify P4 program without deploying (dry-run).
 	@echo "Testing /api/p4/verify endpoint..."
 	@curl -s -X POST http://$(API_HOST)/api/p4/verify \
 		-H "Content-Type: application/json" \
-		-d '{"program": "", "dry_run": true}' | jq . || echo "Error: Could not reach verify endpoint"
+		-d '{"program": "https://raw.githubusercontent.com/mantra6g/iml/main/examples/simple/logger.p4", "dry_run": true}' | jq . || echo "Error: Could not reach verify endpoint"
 
 .PHONY: api-all-tests
 api-all-tests: api-health api-tables api-counters api-get-program ## Run all API endpoint tests.

--- a/targets/bmv2/api/p4loader.go
+++ b/targets/bmv2/api/p4loader.go
@@ -10,9 +10,9 @@ import (
 
 // P4Program represents a compiled P4 program with device config
 type P4Program struct {
-	P4DeviceConfig []byte               // BMv2 JSON device config
+	P4DeviceConfig []byte // BMv2 JSON device config
 	ProgramName    string
-	P4Info         *p4configv1.P4Info   // Parsed P4Info from compilation
+	P4Info         *p4configv1.P4Info // Parsed P4Info from compilation
 }
 
 // LoadP4ProgramFromFiles loads P4DeviceConfig from file paths

--- a/targets/bmv2/api/types.go
+++ b/targets/bmv2/api/types.go
@@ -92,8 +92,8 @@ type InstallTableEntriesRequest struct {
 
 // TableEntriesOperationResponse is the response body for POST and DELETE /api/tables
 type TableEntriesOperationResponse struct {
-	Status  string `json:"status"`
-	Count   int    `json:"count"`
+	Status string `json:"status"`
+	Count  int    `json:"count"`
 }
 
 // RegisterMetadata describes a P4 register array from P4Info.
@@ -122,4 +122,3 @@ type RegistersResponse struct {
 	Registers []RegisterArrayResponse `json:"registers"`
 	Error     string                  `json:"error,omitempty"`
 }
-

--- a/targets/bmv2/cmd/main.go
+++ b/targets/bmv2/cmd/main.go
@@ -180,13 +180,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	nfMgr, err := nfmgr.NewManager()
+	nfMgr, err := nfmgr.NewManager(nfmgr.ManagerConfig{
+		P4Client:        c,
+		DeviceID:        deviceID,
+		ElectionIDHigh:  electionIDHigh,
+		ElectionIDLow:   electionIDLow,
+		P4TargetManager: p4targetMgr,
+	})
 	if err != nil {
 		setupLog.Error(err, "unable to create nf manager")
 		os.Exit(1)
 	}
 
-	nfcfgMgr, err := nfcfgmgr.NewManager()
+	nfcfgMgr, err := nfcfgmgr.NewManager(nfcfgmgr.ManagerConfig{
+		P4Client:       c,
+		DeviceID:       deviceID,
+		ElectionIDHigh: electionIDHigh,
+		ElectionIDLow:  electionIDLow,
+	})
 	if err != nil {
 		setupLog.Error(err, "unable to create nfcfg manager")
 		os.Exit(1)

--- a/targets/bmv2/handlers/program.go
+++ b/targets/bmv2/handlers/program.go
@@ -321,6 +321,10 @@ func downloadFile(url, destPath string) error {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("failed to download P4 file: HTTP %d from %s", resp.StatusCode, url)
+	}
+
 	f, err := os.Create(destPath)
 	if err != nil {
 		return fmt.Errorf("failed to create input file: %w", err)

--- a/targets/bmv2/managers/nf/nf_mgr.go
+++ b/targets/bmv2/managers/nf/nf_mgr.go
@@ -3,19 +3,37 @@ package nf
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
 
+	"bmv2-driver/api"
+	p4targetpkg "bmv2-driver/managers/p4target"
+
+	oldproto "github.com/golang/protobuf/proto"
 	corev1alpha1 "github.com/mantra6g/iml/api/core/v1alpha1"
+	p4configv1 "github.com/p4lang/p4runtime/go/p4/config/v1"
+	p4v1 "github.com/p4lang/p4runtime/go/p4/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type ManagerConfig struct {
+	P4Client        p4v1.P4RuntimeClient
+	DeviceID        uint64
+	ElectionIDHigh  uint64
+	ElectionIDLow   uint64
+	P4TargetManager p4targetpkg.Manager
+}
 
 type Manager interface {
 	GetDeployedNetworkFunctions() []client.ObjectKey
 	EnsurePresent(ctx context.Context, nf *corev1alpha1.NetworkFunction) DeploymentHandle
 	EnsureAbsent(ctx context.Context, nf *corev1alpha1.NetworkFunction) DeploymentHandle
-}
-
-type RealManager struct {
-	ops map[client.ObjectKey]*trackedOp
 }
 
 type operationType string
@@ -30,20 +48,46 @@ type trackedOp struct {
 	opType operationType
 }
 
-func NewManager() (Manager, error) {
-	return nil, fmt.Errorf("not implemented")
+type RealManager struct {
+	p4client        p4v1.P4RuntimeClient
+	deviceID        uint64
+	electionIDHigh  uint64
+	electionIDLow   uint64
+	p4targetManager p4targetpkg.Manager
+
+	mu       sync.Mutex
+	programs map[client.ObjectKey]*api.P4Program
+	ops      map[client.ObjectKey]*trackedOp
 }
 
+// Compile-time assertion to ensure RealManager implements the Manager interface
 var _ Manager = &RealManager{}
+
+func NewManager(cfg ManagerConfig) (Manager, error) {
+	if cfg.P4Client == nil {
+		return nil, fmt.Errorf("P4Runtime client is required")
+	}
+	if cfg.P4TargetManager == nil {
+		return nil, fmt.Errorf("P4Target manager is required")
+	}
+	return &RealManager{
+		p4client:        cfg.P4Client,
+		deviceID:        cfg.DeviceID,
+		electionIDHigh:  cfg.ElectionIDHigh,
+		electionIDLow:   cfg.ElectionIDLow,
+		p4targetManager: cfg.P4TargetManager,
+		programs:        make(map[client.ObjectKey]*api.P4Program),
+		ops:             make(map[client.ObjectKey]*trackedOp),
+	}, nil
+}
 
 func (m *RealManager) EnsurePresent(ctx context.Context, nf *corev1alpha1.NetworkFunction) DeploymentHandle {
 	key := client.ObjectKeyFromObject(nf)
 
 	if existing, ok := m.ops[key]; ok {
 		if existing.opType == opPresent {
-			return existing.handle // already deleting
+			return existing.handle // already deploying
 		}
-
 		// switching from delete → deploy
 		existing.handle.Cancel()
 	}
@@ -68,7 +112,6 @@ func (m *RealManager) EnsureAbsent(ctx context.Context, nf *corev1alpha1.Network
 		if existing.opType == opAbsent {
 			return existing.handle // already deleting
 		}
-
 		// switching from deploy → delete
 		existing.handle.Cancel()
 	}
@@ -103,51 +146,99 @@ func (m *RealManager) runDeployment(ctx context.Context, h *deploymentHandle, nf
 		}
 	}()
 
-	// TODO: Change the next code as you want. Remember to update the phase and message in the handle at
-	//   each step, and to set the phase to PhaseFailed if any step fails. The current code is just a
-	//   skeleton to show you how you might structure the deployment process.
-
-	// --- Compile ---
 	h.transition(PhaseCompiling, "compiling network function", nil)
-
 	if err := m.compile(ctx, nf); err != nil {
 		h.transition(PhaseFailed, "compilation failed", err)
 		return
 	}
 
-	// --- Pre-check ---
 	h.transition(PhasePreCheck, "running pre-deployment checks", nil)
-
 	if err := m.preCheck(ctx, nf); err != nil {
 		h.transition(PhaseFailed, "pre-check failed", err)
 		return
 	}
 
-	// --- Deploy ---
 	h.transition(PhaseDeploying, "deploying network function", nil)
-
 	if err := m.deploy(ctx, nf); err != nil {
 		h.transition(PhaseFailed, "deployment failed", err)
 		return
 	}
 
-	// --- Done ---
 	h.transition(PhaseReady, "network function ready", nil)
 }
 
+// compile fetches the P4 source (URL or base64-encoded BMv2 JSON) and produces
+// a compiled P4Program stored in the programs map for use by deploy.
 func (m *RealManager) compile(ctx context.Context, nf *corev1alpha1.NetworkFunction) error {
-	// TODO: implement or replace this function with another one
+	key := client.ObjectKeyFromObject(nf)
+	p4File := nf.Spec.P4File
+
+	var program *api.P4Program
+	var err error
+
+	if strings.HasPrefix(p4File, "http://") || strings.HasPrefix(p4File, "https://") || strings.HasPrefix(p4File, "s3://") {
+		program, err = compileFromURL(ctx, p4File, nf.Name)
+	} else {
+		// Treat as base64-encoded pre-compiled BMv2 JSON device config.
+		program, err = api.LoadP4ProgramFromBase64(p4File, nf.Name)
+	}
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	m.programs[key] = program
+	m.mu.Unlock()
 	return nil
 }
 
-func (m *RealManager) preCheck(ctx context.Context, nf *corev1alpha1.NetworkFunction) error {
-	// TODO: implement or replace this function with another one
+// preCheck verifies there are available NF slots and table entries before deploying.
+func (m *RealManager) preCheck(_ context.Context, _ *corev1alpha1.NetworkFunction) error {
+	allocatable := m.p4targetManager.GetAllocatable()
+
+	slots := allocatable[p4targetpkg.ResourceNFSlots]
+	if slots.Cmp(resource.MustParse("1")) < 0 {
+		return fmt.Errorf("no NF slots available on target")
+	}
+
+	if tableEntries, ok := allocatable[p4targetpkg.ResourceTableEntries]; ok {
+		if tableEntries.Cmp(resource.MustParse("1")) < 0 {
+			return fmt.Errorf("no table entries available on target")
+		}
+	}
+
 	return nil
 }
 
+// deploy pushes the compiled P4 program to the BMv2 switch.
 func (m *RealManager) deploy(ctx context.Context, nf *corev1alpha1.NetworkFunction) error {
-	// TODO: implement or replace this function with another one
-	return nil
+	key := client.ObjectKeyFromObject(nf)
+
+	m.mu.Lock()
+	program := m.programs[key]
+	m.mu.Unlock()
+
+	if program == nil {
+		return fmt.Errorf("no compiled program for %s", key)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req := &p4v1.SetForwardingPipelineConfigRequest{
+		DeviceId:   m.deviceID,
+		ElectionId: &p4v1.Uint128{High: m.electionIDHigh, Low: m.electionIDLow},
+		Action:     p4v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
+		Config: &p4v1.ForwardingPipelineConfig{
+			P4DeviceConfig: program.P4DeviceConfig,
+		},
+	}
+	if program.P4Info != nil {
+		req.Config.P4Info = program.P4Info
+	}
+
+	_, err := m.p4client.SetForwardingPipelineConfig(reqCtx, req)
+	return err
 }
 
 func (m *RealManager) runDeletion(ctx context.Context, h *deploymentHandle, nf *corev1alpha1.NetworkFunction) {
@@ -158,14 +249,12 @@ func (m *RealManager) runDeletion(ctx context.Context, h *deploymentHandle, nf *
 	}()
 
 	h.transition(PhaseDraining, "draining traffic", nil)
-
 	if err := m.drain(ctx, nf); err != nil {
 		h.transition(PhaseFailed, "drain failed", err)
 		return
 	}
 
 	h.transition(PhaseDeleting, "removing resources", nil)
-
 	if err := m.deleteResources(ctx, nf); err != nil {
 		h.transition(PhaseFailed, "deletion failed", err)
 		return
@@ -174,10 +263,95 @@ func (m *RealManager) runDeletion(ctx context.Context, h *deploymentHandle, nf *
 	h.transition(PhaseDeleted, "successfully deleted", nil)
 }
 
-func (m *RealManager) deleteResources(ctx context.Context, nf *corev1alpha1.NetworkFunction) error {
+// drain is a no-op for BMv2: the switch has no per-NF traffic queuing to flush.
+func (m *RealManager) drain(_ context.Context, _ *corev1alpha1.NetworkFunction) error {
 	return nil
 }
 
-func (m *RealManager) drain(ctx context.Context, nf *corev1alpha1.NetworkFunction) error {
+// deleteResources removes the compiled program artifact from the in-memory store.
+func (m *RealManager) deleteResources(_ context.Context, nf *corev1alpha1.NetworkFunction) error {
+	key := client.ObjectKeyFromObject(nf)
+	m.mu.Lock()
+	delete(m.programs, key)
+	m.mu.Unlock()
+	return nil
+}
+
+// compileFromURL downloads a P4 source file from the given URL, compiles it
+// with p4c for the bmv2/v1model target, and returns the resulting P4Program.
+func compileFromURL(ctx context.Context, fileURL, programName string) (*api.P4Program, error) {
+	tmpDir, err := os.MkdirTemp("", "p4compile-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	inputPath := tmpDir + "/input.p4"
+	if err := downloadFile(fileURL, inputPath); err != nil {
+		return nil, err
+	}
+	return compileP4File(ctx, inputPath, tmpDir, programName)
+}
+
+func compileP4File(ctx context.Context, inputPath, outDir, programName string) (*api.P4Program, error) {
+	p4infoPath := outDir + "/p4info.bin"
+
+	compileCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(compileCtx, "p4c",
+		"--target", "bmv2",
+		"--arch", "v1model",
+		"--p4runtime-files", p4infoPath,
+		"--p4runtime-format", "binary",
+		"-o", outDir,
+		inputPath,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("p4c: %s", string(out))
+	}
+
+	jsonBytes, err := os.ReadFile(outDir + "/input.json")
+	if err != nil {
+		return nil, fmt.Errorf("reading compiled JSON: %w", err)
+	}
+
+	p4infoBytes, err := os.ReadFile(p4infoPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading p4info: %w", err)
+	}
+
+	var p4info p4configv1.P4Info
+	if err := oldproto.Unmarshal(p4infoBytes, &p4info); err != nil {
+		return nil, fmt.Errorf("parsing p4info: %w", err)
+	}
+
+	return &api.P4Program{
+		P4DeviceConfig: jsonBytes,
+		ProgramName:    programName,
+		P4Info:         &p4info,
+	}, nil
+}
+
+func downloadFile(fileURL, destPath string) error {
+	resp, err := http.Get(fileURL) //nolint:noctx
+	if err != nil {
+		return fmt.Errorf("downloading %q: %w", fileURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("downloading %q: HTTP %d", fileURL, resp.StatusCode)
+	}
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("creating file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("writing file: %w", err)
+	}
 	return nil
 }

--- a/targets/bmv2/managers/nfcfg/nfcfg_mgr.go
+++ b/targets/bmv2/managers/nfcfg/nfcfg_mgr.go
@@ -1,11 +1,24 @@
 package nfcfg
 
 import (
+	"context"
 	"fmt"
+	"sync"
+	"time"
+
+	"bmv2-driver/api"
 
 	corev1alpha1 "github.com/mantra6g/iml/api/core/v1alpha1"
+	p4v1 "github.com/p4lang/p4runtime/go/p4/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type ManagerConfig struct {
+	P4Client       p4v1.P4RuntimeClient
+	DeviceID       uint64
+	ElectionIDHigh uint64
+	ElectionIDLow  uint64
+}
 
 type Manager interface {
 	EnsurePresentConfigForNF(nfConfig *corev1alpha1.NetworkFunctionConfig, nf *corev1alpha1.NetworkFunction) error
@@ -13,28 +26,188 @@ type Manager interface {
 	GetAllNetworkFunctionsUsingConfig(nfCfgID client.ObjectKey) ([]client.ObjectKey, error)
 }
 
+// appliedState tracks the table entries that were written to the switch for one NF.
+type appliedState struct {
+	resourceVersion string
+	entries         []*p4v1.TableEntry
+}
+
 type RealManager struct {
+	p4client       p4v1.P4RuntimeClient
+	deviceID       uint64
+	electionIDHigh uint64
+	electionIDLow  uint64
+
+	mu          sync.RWMutex
+	configToNFs map[client.ObjectKey]map[client.ObjectKey]struct{} // configKey -> set of nfKeys
+	nfApplied   map[client.ObjectKey]*appliedState                 // nfKey -> applied state
 }
 
 var _ Manager = &RealManager{}
 
-func NewManager() (Manager, error) {
-	return nil, fmt.Errorf("not implemented")
+func NewManager(cfg ManagerConfig) (Manager, error) {
+	if cfg.P4Client == nil {
+		return nil, fmt.Errorf("P4Runtime client is required")
+	}
+	return &RealManager{
+		p4client:       cfg.P4Client,
+		deviceID:       cfg.DeviceID,
+		electionIDHigh: cfg.ElectionIDHigh,
+		electionIDLow:  cfg.ElectionIDLow,
+		configToNFs:    make(map[client.ObjectKey]map[client.ObjectKey]struct{}),
+		nfApplied:      make(map[client.ObjectKey]*appliedState),
+	}, nil
 }
 
-func (m *RealManager) EnsurePresentConfigForNF(nfConfig *corev1alpha1.NetworkFunctionConfig,
-	nf *corev1alpha1.NetworkFunction) error {
-	// TODO: implement
-	return fmt.Errorf("not implemented")
+// EnsurePresentConfigForNF applies the table entries from nfConfig to the switch for the given NF.
+// If nfConfig is nil the call is a no-op. If the program is not yet loaded the call returns nil
+// and the reconciler will retry on the next cycle.
+func (m *RealManager) EnsurePresentConfigForNF(nfConfig *corev1alpha1.NetworkFunctionConfig, nf *corev1alpha1.NetworkFunction) error {
+	nfKey := client.ObjectKeyFromObject(nf)
+
+	if nfConfig == nil {
+		m.mu.Lock()
+		delete(m.nfApplied, nfKey)
+		m.mu.Unlock()
+		return nil
+	}
+
+	configKey := client.ObjectKeyFromObject(nfConfig)
+
+	m.mu.RLock()
+	existing := m.nfApplied[nfKey]
+	m.mu.RUnlock()
+
+	if existing != nil && existing.resourceVersion == nfConfig.ResourceVersion {
+		return nil // already up to date
+	}
+
+	tables, err := m.fetchTableMetadata()
+	if err != nil {
+		return fmt.Errorf("fetching P4Info: %w", err)
+	}
+	if tables == nil {
+		return nil // no program loaded yet; reconciler will retry
+	}
+
+	entries, err := buildTableEntries(nfConfig.Spec.Tables, tables)
+	if err != nil {
+		return fmt.Errorf("building table entries: %w", err)
+	}
+
+	if existing != nil && len(existing.entries) > 0 {
+		if err := m.writeEntries(existing.entries, p4v1.Update_DELETE); err != nil {
+			return fmt.Errorf("removing stale entries: %w", err)
+		}
+	}
+
+	if len(entries) > 0 {
+		if err := m.writeEntries(entries, p4v1.Update_INSERT); err != nil {
+			return fmt.Errorf("inserting table entries: %w", err)
+		}
+	}
+
+	m.mu.Lock()
+	m.nfApplied[nfKey] = &appliedState{
+		resourceVersion: nfConfig.ResourceVersion,
+		entries:         entries,
+	}
+	if m.configToNFs[configKey] == nil {
+		m.configToNFs[configKey] = make(map[client.ObjectKey]struct{})
+	}
+	m.configToNFs[configKey][nfKey] = struct{}{}
+	m.mu.Unlock()
+
+	return nil
 }
 
-func (m *RealManager) EnsureAbsentConfig(nfConfig *corev1alpha1.NetworkFunctionConfig,
-	nf *corev1alpha1.NetworkFunction) error {
-	// TODO: implement
-	return fmt.Errorf("not implemented")
+// EnsureAbsentConfig removes the table entries that were applied for the given NF.
+func (m *RealManager) EnsureAbsentConfig(nfConfig *corev1alpha1.NetworkFunctionConfig, nf *corev1alpha1.NetworkFunction) error {
+	nfKey := client.ObjectKeyFromObject(nf)
+
+	m.mu.RLock()
+	existing := m.nfApplied[nfKey]
+	m.mu.RUnlock()
+
+	if existing == nil || len(existing.entries) == 0 {
+		return nil
+	}
+
+	tables, err := m.fetchTableMetadata()
+	if err != nil || tables == nil {
+		// Program may have been unloaded; clean up tracking regardless.
+		m.removeTracking(nfKey, nfConfig)
+		return nil
+	}
+
+	if err := m.writeEntries(existing.entries, p4v1.Update_DELETE); err != nil {
+		return fmt.Errorf("deleting table entries: %w", err)
+	}
+
+	m.removeTracking(nfKey, nfConfig)
+	return nil
 }
 
+// GetAllNetworkFunctionsUsingConfig returns all NF keys that reference the given config.
 func (m *RealManager) GetAllNetworkFunctionsUsingConfig(nfCfgID client.ObjectKey) ([]client.ObjectKey, error) {
-	// TODO: implement
-	return nil, fmt.Errorf("not implemented")
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	nfs := m.configToNFs[nfCfgID]
+	result := make([]client.ObjectKey, 0, len(nfs))
+	for key := range nfs {
+		result = append(result, key)
+	}
+	return result, nil
+}
+
+func (m *RealManager) fetchTableMetadata() ([]api.TableMetadata, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := m.p4client.GetForwardingPipelineConfig(ctx, &p4v1.GetForwardingPipelineConfigRequest{
+		ResponseType: p4v1.GetForwardingPipelineConfigRequest_P4INFO_AND_COOKIE,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Config == nil || resp.Config.P4Info == nil || len(resp.Config.P4Info.Tables) == 0 {
+		return nil, nil
+	}
+	return api.GetTableMetadata(&api.P4Program{P4Info: resp.Config.P4Info}), nil
+}
+
+func (m *RealManager) writeEntries(entries []*p4v1.TableEntry, updateType p4v1.Update_Type) error {
+	updates := make([]*p4v1.Update, 0, len(entries))
+	for _, e := range entries {
+		updates = append(updates, &p4v1.Update{
+			Type:   updateType,
+			Entity: &p4v1.Entity{Entity: &p4v1.Entity_TableEntry{TableEntry: e}},
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := m.p4client.Write(ctx, &p4v1.WriteRequest{
+		DeviceId:   m.deviceID,
+		ElectionId: &p4v1.Uint128{High: m.electionIDHigh, Low: m.electionIDLow},
+		Updates:    updates,
+	})
+	return err
+}
+
+func (m *RealManager) removeTracking(nfKey client.ObjectKey, nfConfig *corev1alpha1.NetworkFunctionConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.nfApplied, nfKey)
+	if nfConfig != nil {
+		configKey := client.ObjectKeyFromObject(nfConfig)
+		if nfs := m.configToNFs[configKey]; nfs != nil {
+			delete(nfs, nfKey)
+			if len(nfs) == 0 {
+				delete(m.configToNFs, configKey)
+			}
+		}
+	}
 }

--- a/targets/bmv2/managers/nfcfg/table_entry_builder.go
+++ b/targets/bmv2/managers/nfcfg/table_entry_builder.go
@@ -1,0 +1,266 @@
+package nfcfg
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+
+	"bmv2-driver/api"
+	corev1alpha1 "github.com/mantra6g/iml/api/core/v1alpha1"
+	p4v1 "github.com/p4lang/p4runtime/go/p4/v1"
+)
+
+// buildTableEntries translates a NetworkFunctionConfig table map into P4Runtime
+// TableEntry objects using the table/field/action metadata from the loaded P4 program.
+func buildTableEntries(tables map[string]corev1alpha1.TableConfig, tableMetas []api.TableMetadata) ([]*p4v1.TableEntry, error) {
+	metaByName := make(map[string]*api.TableMetadata, len(tableMetas))
+	for i := range tableMetas {
+		metaByName[tableMetas[i].TableName] = &tableMetas[i]
+	}
+
+	var entries []*p4v1.TableEntry
+	for tableName, tableConfig := range tables {
+		meta, ok := metaByName[tableName]
+		if !ok {
+			return nil, fmt.Errorf("table %q not found in loaded P4 program", tableName)
+		}
+
+		if tableConfig.DefaultAction != nil {
+			entry, err := buildDefaultActionEntry(meta, tableConfig.DefaultAction)
+			if err != nil {
+				return nil, fmt.Errorf("default action for table %q: %w", tableName, err)
+			}
+			entries = append(entries, entry)
+		}
+
+		for i := range tableConfig.Entries {
+			entry, err := buildTableEntry(meta, &tableConfig.Entries[i])
+			if err != nil {
+				return nil, fmt.Errorf("entry %d in table %q: %w", i, tableName, err)
+			}
+			entries = append(entries, entry)
+		}
+	}
+	return entries, nil
+}
+
+func buildDefaultActionEntry(meta *api.TableMetadata, action *corev1alpha1.ActionConfig) (*p4v1.TableEntry, error) {
+	a, err := buildAction(*action, meta.Actions)
+	if err != nil {
+		return nil, err
+	}
+	return &p4v1.TableEntry{
+		TableId:         meta.TableID,
+		IsDefaultAction: true,
+		Action:          &p4v1.TableAction{Type: &p4v1.TableAction_Action{Action: a}},
+	}, nil
+}
+
+func buildTableEntry(meta *api.TableMetadata, cfgEntry *corev1alpha1.TableEntry) (*p4v1.TableEntry, error) {
+	fieldByName := make(map[string]*api.MatchFieldMetadata, len(meta.MatchFields))
+	for i := range meta.MatchFields {
+		fieldByName[meta.MatchFields[i].FieldName] = &meta.MatchFields[i]
+	}
+
+	matches := make([]*p4v1.FieldMatch, 0, len(cfgEntry.MatchFields))
+	for _, mf := range cfgEntry.MatchFields {
+		fieldMeta, ok := fieldByName[mf.Name]
+		if !ok {
+			return nil, fmt.Errorf("match field %q not found in table %q", mf.Name, meta.TableName)
+		}
+		fm, err := buildFieldMatch(mf, fieldMeta)
+		if err != nil {
+			return nil, fmt.Errorf("match field %q: %w", mf.Name, err)
+		}
+		matches = append(matches, fm)
+	}
+
+	a, err := buildAction(cfgEntry.Action, meta.Actions)
+	if err != nil {
+		return nil, err
+	}
+
+	return &p4v1.TableEntry{
+		TableId: meta.TableID,
+		Match:   matches,
+		Action:  &p4v1.TableAction{Type: &p4v1.TableAction_Action{Action: a}},
+	}, nil
+}
+
+func buildFieldMatch(mf corev1alpha1.MatchField, meta *api.MatchFieldMetadata) (*p4v1.FieldMatch, error) {
+	fm := &p4v1.FieldMatch{FieldId: meta.FieldID}
+	byteLen := int((meta.Bitwidth + 7) / 8)
+
+	switch mf.Type {
+	case corev1alpha1.ExactMatch:
+		if mf.Exact == nil {
+			return nil, fmt.Errorf("missing exact value")
+		}
+		val, err := encodeValue(*mf.Exact, meta.Bitwidth)
+		if err != nil {
+			return nil, err
+		}
+		fm.FieldMatchType = &p4v1.FieldMatch_Exact_{Exact: &p4v1.FieldMatch_Exact{Value: val}}
+
+	case corev1alpha1.TernaryMatch:
+		if mf.Ternary == nil {
+			return nil, fmt.Errorf("missing ternary value")
+		}
+		val, err := encodeValue(mf.Ternary.Value, meta.Bitwidth)
+		if err != nil {
+			return nil, fmt.Errorf("value: %w", err)
+		}
+		mask, err := encodeHexString(mf.Ternary.Mask, byteLen)
+		if err != nil {
+			return nil, fmt.Errorf("mask: %w", err)
+		}
+		fm.FieldMatchType = &p4v1.FieldMatch_Ternary_{Ternary: &p4v1.FieldMatch_Ternary{Value: val, Mask: mask}}
+
+	case corev1alpha1.LPMMatch:
+		if mf.LPM == nil {
+			return nil, fmt.Errorf("missing LPM value")
+		}
+		val, err := encodeValue(mf.LPM.Value, meta.Bitwidth)
+		if err != nil {
+			return nil, err
+		}
+		prefixLen, err := strconv.ParseInt(mf.LPM.PrefixLen, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid prefix length %q: %w", mf.LPM.PrefixLen, err)
+		}
+		fm.FieldMatchType = &p4v1.FieldMatch_Lpm{Lpm: &p4v1.FieldMatch_LPM{Value: val, PrefixLen: int32(prefixLen)}}
+
+	case corev1alpha1.RangeMatch:
+		if mf.Range == nil {
+			return nil, fmt.Errorf("missing range value")
+		}
+		low, err := encodeValue(mf.Range.Low, meta.Bitwidth)
+		if err != nil {
+			return nil, fmt.Errorf("range low: %w", err)
+		}
+		high, err := encodeValue(mf.Range.High, meta.Bitwidth)
+		if err != nil {
+			return nil, fmt.Errorf("range high: %w", err)
+		}
+		fm.FieldMatchType = &p4v1.FieldMatch_Range_{Range: &p4v1.FieldMatch_Range{Low: low, High: high}}
+
+	case corev1alpha1.OptionalMatch:
+		if mf.Optional == nil {
+			return nil, fmt.Errorf("missing optional value")
+		}
+		val, err := encodeValue(*mf.Optional, meta.Bitwidth)
+		if err != nil {
+			return nil, err
+		}
+		fm.FieldMatchType = &p4v1.FieldMatch_Optional_{Optional: &p4v1.FieldMatch_Optional{Value: val}}
+
+	default:
+		return nil, fmt.Errorf("unsupported match type %q", mf.Type)
+	}
+	return fm, nil
+}
+
+func buildAction(action corev1alpha1.ActionConfig, actions []api.ActionMetadata) (*p4v1.Action, error) {
+	var actionMeta *api.ActionMetadata
+	for i := range actions {
+		if actions[i].ActionName == action.Name {
+			actionMeta = &actions[i]
+			break
+		}
+	}
+	if actionMeta == nil {
+		return nil, fmt.Errorf("action %q not found in P4 program", action.Name)
+	}
+
+	paramByName := make(map[string]*api.ActionParamMetadata, len(actionMeta.Params))
+	for i := range actionMeta.Params {
+		paramByName[actionMeta.Params[i].Name] = &actionMeta.Params[i]
+	}
+
+	params := make([]*p4v1.Action_Param, 0, len(action.Parameters))
+	for _, p := range action.Parameters {
+		paramMeta, ok := paramByName[p.Name]
+		if !ok {
+			return nil, fmt.Errorf("param %q not found in action %q", p.Name, action.Name)
+		}
+		val, err := encodeValue(p.Value, paramMeta.Bitwidth)
+		if err != nil {
+			return nil, fmt.Errorf("param %q: %w", p.Name, err)
+		}
+		params = append(params, &p4v1.Action_Param{
+			ParamId: paramMeta.ParamID,
+			Value:   val,
+		})
+	}
+
+	return &p4v1.Action{
+		ActionId: actionMeta.ActionID,
+		Params:   params,
+	}, nil
+}
+
+// encodeValue converts a ParametrizedValue to a big-endian byte slice padded to bitwidth.
+func encodeValue(v corev1alpha1.ParametrizedValue, bitwidth int32) ([]byte, error) {
+	byteLen := int((bitwidth + 7) / 8)
+
+	if v.RawHex != nil {
+		return encodeHexString(*v.RawHex, byteLen)
+	}
+	if v.Int != nil {
+		n, ok := new(big.Int).SetString(*v.Int, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid integer %q", *v.Int)
+		}
+		return padToWidth(n.Bytes(), byteLen), nil
+	}
+	if v.IPv4Address != nil {
+		ip := net.ParseIP(*v.IPv4Address).To4()
+		if ip == nil {
+			return nil, fmt.Errorf("invalid IPv4 address %q", *v.IPv4Address)
+		}
+		return ip, nil
+	}
+	if v.IPv6Address != nil {
+		ip := net.ParseIP(*v.IPv6Address).To16()
+		if ip == nil {
+			return nil, fmt.Errorf("invalid IPv6 address %q", *v.IPv6Address)
+		}
+		return ip, nil
+	}
+	if v.MACAddress != nil {
+		mac, err := net.ParseMAC(*v.MACAddress)
+		if err != nil {
+			return nil, fmt.Errorf("invalid MAC address %q: %w", *v.MACAddress, err)
+		}
+		return mac, nil
+	}
+	return nil, fmt.Errorf("ParametrizedValue has no value set")
+}
+
+func encodeHexString(s string, byteLen int) ([]byte, error) {
+	s = strings.TrimPrefix(s, "0x")
+	s = strings.TrimPrefix(s, "0X")
+	if len(s)%2 != 0 {
+		s = "0" + s
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid hex string %q: %w", s, err)
+	}
+	return padToWidth(b, byteLen), nil
+}
+
+func padToWidth(b []byte, size int) []byte {
+	if len(b) == size {
+		return b
+	}
+	if len(b) > size {
+		return b[len(b)-size:]
+	}
+	padded := make([]byte, size)
+	copy(padded[size-len(b):], b)
+	return padded
+}


### PR DESCRIPTION
Implement the NF lifecycle (compile, preCheck, deploy, drain,
deleteResources) and NFConfig table entry management against the BMv2
P4Runtime API. NewManager now requires a ManagerConfig with the
P4Runtime client, device ID, election IDs, and P4Target manager.