### PR TITLE
Wire iml0 and nf0 interfaces via Multus CNI in test environment

### DIFF
--- a/targets/bmv2/cmd/main.go
+++ b/targets/bmv2/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -74,7 +75,7 @@ func main() {
 	flag.IntVar(&maxNFSlots, "max-nf-slots",
 		DefaultMaxNFSlots, "Maximum number of network functions this target can host")
 	flag.StringVar(&dataIface, "data-iface",
-		"iml0", "Network interface to discover target IPs from")
+		"iml0", "Comma-separated network interfaces to discover target IPs from")
 
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
@@ -252,19 +253,25 @@ func main() {
 	}
 }
 
-func discoverIPs(ifaceName string) ([]net.IP, error) {
-	link, err := netlink.LinkByName(ifaceName)
-	if err != nil {
-		return nil, fmt.Errorf("interface %q not found: %w", ifaceName, err)
-	}
-	addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list addresses on %q: %w", ifaceName, err)
-	}
-	ips := make([]net.IP, 0, len(addrs))
-	for _, a := range addrs {
-		if a.IP != nil {
-			ips = append(ips, a.IP)
+func discoverIPs(ifaceNames string) ([]net.IP, error) {
+	var ips []net.IP
+	for _, name := range strings.Split(ifaceNames, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		link, err := netlink.LinkByName(name)
+		if err != nil {
+			return nil, fmt.Errorf("interface %q not found: %w", name, err)
+		}
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list addresses on %q: %w", name, err)
+		}
+		for _, a := range addrs {
+			if a.IP != nil {
+				ips = append(ips, a.IP)
+			}
 		}
 	}
 	return ips, nil

--- a/targets/bmv2/cmd/main.go
+++ b/targets/bmv2/cmd/main.go
@@ -60,7 +60,7 @@ func init() {
 func main() {
 	var leaseRenewIntervalSeconds, leaseDurationSeconds uint
 	var maxNFSlots int
-	var p4targetName, switchAddr, driverIP, dataIface string
+	var p4targetName, switchAddr, driverIP, dataIface, nfIface string
 
 	flag.UintVar(&leaseRenewIntervalSeconds, "lease-renew-interval-seconds",
 		DefaultLeaseRenewIntervalSeconds, "Interval at which to renew the Lease for this P4Target")
@@ -76,6 +76,8 @@ func main() {
 		DefaultMaxNFSlots, "Maximum number of network functions this target can host")
 	flag.StringVar(&dataIface, "data-iface",
 		"iml0", "Comma-separated network interfaces to discover target IPs from")
+	flag.StringVar(&nfIface, "nf-iface",
+		"nf0", "Network interface to assign allocated NF IPs to")
 
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
@@ -176,6 +178,7 @@ func main() {
 		MaxNFSlots: maxNFSlots,
 		TargetIPs:  targetIPs,
 		DriverIP:   net.ParseIP(driverIP),
+		NFIface:    nfIface,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to create p4target manager")

--- a/targets/bmv2/controllers/nf/nf_controller.go
+++ b/targets/bmv2/controllers/nf/nf_controller.go
@@ -201,8 +201,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, err
 		}
 	}
-	//TODO: What do we do now with this IP? How should the manager retrieve this IP?
-
 	var nfConfig *corev1alpha1.NetworkFunctionConfig
 	if netfunc.Spec.ConfigRef != nil {
 		nfConfig = &corev1alpha1.NetworkFunctionConfig{}

--- a/targets/bmv2/managers/nf/nf_mgr_types.go
+++ b/targets/bmv2/managers/nf/nf_mgr_types.go
@@ -7,9 +7,6 @@ import (
 
 type Phase string
 
-// TODO: make sure to add or remove any phases that are relevant for your deployment process.
-//
-//	The ones listed here are just examples.
 const (
 	// deploy phases
 	PhaseCompiling Phase = "Compiling"

--- a/targets/bmv2/managers/p4target/p4target_mgr.go
+++ b/targets/bmv2/managers/p4target/p4target_mgr.go
@@ -2,17 +2,20 @@ package p4target
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
 	"sync"
 	"time"
 
+	"github.com/vishvananda/netlink"
 	corev1alpha1 "github.com/mantra6g/iml/api/core/v1alpha1"
 	p4v1 "github.com/p4lang/p4runtime/go/p4/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"golang.org/x/sys/unix"
 
 	"bmv2-driver/pkg/ipam"
 )
@@ -33,6 +36,7 @@ type ManagerConfig struct {
 	DriverIP   net.IP
 	MaxNFSlots int
 	P4Client   p4v1.P4RuntimeClient
+	NFIface    string // kernel interface to assign NF IPs to (e.g. "nf0")
 }
 
 type Manager interface {
@@ -65,6 +69,7 @@ func NewManager(cfg ManagerConfig) (Manager, error) {
 		driverIP:     cfg.DriverIP,
 		maxNFSlots:   cfg.MaxNFSlots,
 		p4client:     cfg.P4Client,
+		nfIface:      cfg.NFIface,
 		allocatedIPs: make(map[netip.Addr]struct{}),
 	}, nil
 }
@@ -78,6 +83,7 @@ type RealManager struct {
 	driverIP   net.IP
 	maxNFSlots int
 	p4client   p4v1.P4RuntimeClient
+	nfIface    string
 
 	mu           sync.RWMutex
 	cidr         netip.Prefix
@@ -127,7 +133,32 @@ func (r *RealManager) AllocateNetworkFunctionIP() (net.IP, error) {
 		return nil, err
 	}
 	r.allocatedIPs[addr] = struct{}{}
-	return net.IP(addr.Unmap().AsSlice()), nil
+	ip := net.IP(addr.Unmap().AsSlice())
+
+	if r.nfIface != "" {
+		if err := assignIPToIface(ip, r.nfIface); err != nil {
+			return nil, fmt.Errorf("assigning IP %s to %s: %w", ip, r.nfIface, err)
+		}
+	}
+	return ip, nil
+}
+
+func assignIPToIface(ip net.IP, ifaceName string) error {
+	link, err := netlink.LinkByName(ifaceName)
+	if err != nil {
+		return fmt.Errorf("interface %q not found: %w", ifaceName, err)
+	}
+	bits := 32
+	if ip.To4() == nil {
+		bits = 128
+	}
+	addr := &netlink.Addr{
+		IPNet: &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)},
+	}
+	if err := netlink.AddrAdd(link, addr); err != nil && !errors.Is(err, unix.EEXIST) {
+		return err
+	}
+	return nil
 }
 
 func (r *RealManager) GetCapacity() corev1.ResourceList {

--- a/targets/bmv2/test.yaml
+++ b/targets/bmv2/test.yaml
@@ -1,3 +1,49 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cni-plugins-installer
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: cni-plugins-installer
+  template:
+    metadata:
+      labels:
+        app: cni-plugins-installer
+    spec:
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: installer
+        image: alpine:3.19
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            if [ ! -f /host/opt/cni/bin/bridge ]; then
+              ARCH=$(uname -m)
+              case $ARCH in
+                x86_64)  ARCH=amd64 ;;
+                aarch64) ARCH=arm64 ;;
+              esac
+              mkdir -p /host/opt/cni/bin
+              wget -qO- https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-${ARCH}-v1.6.2.tgz | tar -xz -C /host/opt/cni/bin
+            fi
+            exec sleep infinity
+        volumeMounts:
+        - name: cni-bin
+          mountPath: /host/opt/cni/bin
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+      volumes:
+      - name: cni-bin
+        hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -23,28 +69,53 @@ subjects:
   name: default
   namespace: default
 ---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: iml0-net
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "iml0-net",
+      "type": "bridge",
+      "bridge": "iml0-br",
+      "ipam": {
+        "type": "static",
+        "addresses": [{"address": "10.0.1.1/24"}]
+      }
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: nf0-net
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "nf0-net",
+      "type": "bridge",
+      "bridge": "nf0-br",
+      "ipam": {
+        "type": "static",
+        "addresses": [{"address": "10.0.2.1/24"}]
+      }
+    }
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: bmv2-test
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[{"name":"iml0-net","interface":"iml0"},{"name":"nf0-net","interface":"nf0"}]'
 spec:
   restartPolicy: OnFailure
-  initContainers:
-  - name: iml0-setup
-    image: alpine:3.19
-    command: ["/bin/sh", "-c"]
-    args:
-      - |
-        ip link add iml0 type dummy
-        ip addr add 10.0.1.1/24 dev iml0
-        ip link set iml0 up
-    securityContext:
-      capabilities:
-        add: ["NET_ADMIN"]
   containers:
   - name: bmv2-driver
     image: bmv2-driver:local
     imagePullPolicy: Never
+    args: ["--data-iface=iml0,nf0"]
     resources:
       requests:
         cpu: 100m
@@ -68,6 +139,8 @@ spec:
       - "--log-console"
       - "-i"
       - "0@iml0"
+      - "-i"
+      - "1@nf0"
       - "--"
       - "--grpc-server-addr=0.0.0.0:9559"
       - "--cpu-port=255"


### PR DESCRIPTION
Replace the init-container approach for creating iml0 with Multus NetworkAttachmentDefinitions so interfaces are managed declaratively by the cluster. Add a DaemonSet that installs the standard CNI plugins (bridge) on kind nodes, which Multus requires but kind does not ship by default.

Add a second data-plane interface nf0 (10.0.2.1/24) attached to the bmv2-switch as port 1. Extend --data-iface to accept a comma-separated list so the driver discovers and reports IPs from both iml0 and nf0.