### PR TITLE
Bmv2target nf management via crd

### DIFF
--- a/targets/bmv2/cmd/main.go
+++ b/targets/bmv2/cmd/main.go
@@ -66,7 +66,7 @@ func main() {
 	flag.UintVar(&leaseDurationSeconds, "lease-duration-seconds",
 		DefaultLeaseDurationSeconds, "Duration of the P4Runtime master lease")
 	flag.StringVar(&p4targetName, "p4target-name",
-		"bmv2-switch", "Name of the P4Target custom resource to manage")
+		"bmv2-target", "Name of the P4Target custom resource to manage")
 	flag.StringVar(&switchAddr, "switch-addr",
 		defaultSwitchAddr, "Address of the P4Runtime gRPC server on the BMv2 switch")
 	flag.StringVar(&driverIP, "driver-ip",

--- a/targets/bmv2/managers/nf/nf_mgr.go
+++ b/targets/bmv2/managers/nf/nf_mgr.go
@@ -1,6 +1,7 @@
 package nf
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -216,7 +217,9 @@ func (m *RealManager) preCheck(_ context.Context, _ *corev1alpha1.NetworkFunctio
 	return nil
 }
 
-// deploy pushes the compiled P4 program to the BMv2 switch.
+// deploy pushes the compiled P4 program to the BMv2 switch. If the switch
+// already has an identical program loaded (e.g. after a driver restart), the
+// SetForwardingPipelineConfig RPC is skipped to avoid unnecessary disruption.
 func (m *RealManager) deploy(ctx context.Context, nf *corev1alpha1.NetworkFunction) error {
 	key := client.ObjectKeyFromObject(nf)
 
@@ -230,6 +233,12 @@ func (m *RealManager) deploy(ctx context.Context, nf *corev1alpha1.NetworkFuncti
 
 	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
+
+	existing, err := m.switchClient.GetPipeline(reqCtx)
+	if err == nil && existing.GetConfig() != nil &&
+		bytes.Equal(existing.Config.P4DeviceConfig, program.P4DeviceConfig) {
+		return nil
+	}
 
 	return m.switchClient.DeployPipeline(reqCtx, program)
 }

--- a/targets/bmv2/managers/nf/nf_mgr_test.go
+++ b/targets/bmv2/managers/nf/nf_mgr_test.go
@@ -1,1 +1,254 @@
 package nf
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	p4targetpkg "bmv2-driver/managers/p4target"
+	p4switch "bmv2-driver/pkg/p4switch"
+
+	corev1alpha1 "github.com/mantra6g/iml/api/core/v1alpha1"
+	p4v1 "github.com/p4lang/p4runtime/go/p4/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ---------------------------------------------------------------------------
+// Mock P4Runtime client
+// ---------------------------------------------------------------------------
+
+type mockP4Client struct {
+	mu sync.Mutex
+
+	getFwdPipelineFn func(*p4v1.GetForwardingPipelineConfigRequest) (*p4v1.GetForwardingPipelineConfigResponse, error)
+	setFwdPipelineFn func(*p4v1.SetForwardingPipelineConfigRequest) (*p4v1.SetForwardingPipelineConfigResponse, error)
+
+	setCalls []*p4v1.SetForwardingPipelineConfigRequest
+}
+
+func (m *mockP4Client) GetForwardingPipelineConfig(_ context.Context, in *p4v1.GetForwardingPipelineConfigRequest, _ ...grpc.CallOption) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+	if m.getFwdPipelineFn != nil {
+		return m.getFwdPipelineFn(in)
+	}
+	return &p4v1.GetForwardingPipelineConfigResponse{}, nil
+}
+
+func (m *mockP4Client) SetForwardingPipelineConfig(_ context.Context, in *p4v1.SetForwardingPipelineConfigRequest, _ ...grpc.CallOption) (*p4v1.SetForwardingPipelineConfigResponse, error) {
+	m.mu.Lock()
+	m.setCalls = append(m.setCalls, in)
+	m.mu.Unlock()
+	if m.setFwdPipelineFn != nil {
+		return m.setFwdPipelineFn(in)
+	}
+	return &p4v1.SetForwardingPipelineConfigResponse{}, nil
+}
+
+func (m *mockP4Client) Read(_ context.Context, _ *p4v1.ReadRequest, _ ...grpc.CallOption) (p4v1.P4Runtime_ReadClient, error) {
+	return &mockReadStream{}, nil
+}
+func (m *mockP4Client) Write(_ context.Context, _ *p4v1.WriteRequest, _ ...grpc.CallOption) (*p4v1.WriteResponse, error) {
+	return nil, nil
+}
+func (m *mockP4Client) StreamChannel(_ context.Context, _ ...grpc.CallOption) (p4v1.P4Runtime_StreamChannelClient, error) {
+	return nil, nil
+}
+func (m *mockP4Client) Capabilities(_ context.Context, _ *p4v1.CapabilitiesRequest, _ ...grpc.CallOption) (*p4v1.CapabilitiesResponse, error) {
+	return nil, nil
+}
+
+func (m *mockP4Client) setCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.setCalls)
+}
+
+type mockReadStream struct{}
+
+func (m *mockReadStream) Recv() (*p4v1.ReadResponse, error)    { return nil, io.EOF }
+func (m *mockReadStream) Header() (metadata.MD, error)        { return nil, nil }
+func (m *mockReadStream) Trailer() metadata.MD                { return nil }
+func (m *mockReadStream) CloseSend() error                    { return nil }
+func (m *mockReadStream) Context() context.Context            { return context.Background() }
+func (m *mockReadStream) SendMsg(_ any) error                 { return nil }
+func (m *mockReadStream) RecvMsg(_ any) error                 { return nil }
+
+// ---------------------------------------------------------------------------
+// Mock P4Target manager
+// ---------------------------------------------------------------------------
+
+type mockP4TargetManager struct{}
+
+func (m *mockP4TargetManager) GetName() string { return "test-target" }
+func (m *mockP4TargetManager) GetAllocatable() corev1.ResourceList {
+	return corev1.ResourceList{
+		p4targetpkg.ResourceNFSlots:      resource.MustParse("10"),
+		p4targetpkg.ResourceTableEntries: resource.MustParse("1000"),
+	}
+}
+func (m *mockP4TargetManager) GetCapacity() corev1.ResourceList { return nil }
+func (m *mockP4TargetManager) GetHealthyCondition() corev1alpha1.P4TargetCondition {
+	return corev1alpha1.P4TargetCondition{}
+}
+func (m *mockP4TargetManager) GetReadyCondition() corev1alpha1.P4TargetCondition {
+	return corev1alpha1.P4TargetCondition{}
+}
+func (m *mockP4TargetManager) GetNetworkConfiguredCondition() corev1alpha1.P4TargetCondition {
+	return corev1alpha1.P4TargetCondition{}
+}
+func (m *mockP4TargetManager) GetOccupiedCondition() corev1alpha1.P4TargetCondition {
+	return corev1alpha1.P4TargetCondition{}
+}
+func (m *mockP4TargetManager) GetTargetIPs() []net.IP           { return nil }
+func (m *mockP4TargetManager) GetDriverIP() net.IP              { return nil }
+func (m *mockP4TargetManager) EnsureNetworkConfiguration(_ p4targetpkg.NetConfig) error {
+	return nil
+}
+func (m *mockP4TargetManager) AllocateNetworkFunctionIP() (net.IP, error) {
+	return net.ParseIP("10.0.0.1"), nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+var testP4Bytes = []byte(`{"test": "program"}`)
+
+func newTestNF(name, namespace string) *corev1alpha1.NetworkFunction {
+	return &corev1alpha1.NetworkFunction{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1alpha1.NetworkFunctionSpec{
+			P4File:     base64.StdEncoding.EncodeToString(testP4Bytes),
+			TargetName: "test-target",
+		},
+	}
+}
+
+func newTestManagerWith(p4c p4v1.P4RuntimeClient, tgtMgr p4targetpkg.Manager) Manager {
+	sc := p4switch.NewSwitchClient(p4c, 0, 1, 0)
+	m, err := NewManager(ManagerConfig{Switch: sc, P4TargetManager: tgtMgr})
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+func waitDone(t *testing.T, h DeploymentHandle) {
+	t.Helper()
+	select {
+	case <-h.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("deployment handle did not reach terminal state within 5s (phase=%s)", h.Status().Phase)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestEnsurePresent_DrivesToPhaseReady verifies that applying a NetworkFunction
+// drives the NF manager through compile/preCheck/deploy and reaches PhaseReady.
+func TestEnsurePresent_DrivesToPhaseReady(t *testing.T) {
+	mock := &mockP4Client{}
+	mgr := newTestManagerWith(mock, &mockP4TargetManager{})
+	nf := newTestNF("test-nf", "test-ns")
+
+	handle := mgr.EnsurePresent(context.Background(), nf)
+	waitDone(t, handle)
+
+	if handle.Status().Phase != PhaseReady {
+		t.Fatalf("expected PhaseReady, got %s: %v", handle.Status().Phase, handle.Err())
+	}
+	if handle.Err() != nil {
+		t.Fatalf("unexpected error: %v", handle.Err())
+	}
+	if mock.setCallCount() != 1 {
+		t.Fatalf("expected 1 SetForwardingPipelineConfig call, got %d", mock.setCallCount())
+	}
+}
+
+// TestEnsureAbsent_ResetsForwardingPipeline verifies that deleting a NetworkFunction
+// causes deleteResources to call ResetPipeline (SetForwardingPipelineConfig with empty config).
+func TestEnsureAbsent_ResetsForwardingPipeline(t *testing.T) {
+	mock := &mockP4Client{}
+	mgr := newTestManagerWith(mock, &mockP4TargetManager{})
+	nf := newTestNF("test-nf", "test-ns")
+
+	// Deploy first.
+	deployHandle := mgr.EnsurePresent(context.Background(), nf)
+	waitDone(t, deployHandle)
+	if deployHandle.Status().Phase != PhaseReady {
+		t.Fatalf("setup: expected PhaseReady, got %s", deployHandle.Status().Phase)
+	}
+
+	// Now delete.
+	deleteHandle := mgr.EnsureAbsent(context.Background(), nf)
+	waitDone(t, deleteHandle)
+
+	if deleteHandle.Status().Phase != PhaseDeleted {
+		t.Fatalf("expected PhaseDeleted, got %s: %v", deleteHandle.Status().Phase, deleteHandle.Err())
+	}
+
+	// Verify that a reset call (empty P4DeviceConfig) was made.
+	mock.mu.Lock()
+	calls := mock.setCalls
+	mock.mu.Unlock()
+	resetFound := false
+	for _, req := range calls {
+		if req.Config != nil && len(req.Config.P4DeviceConfig) == 0 {
+			resetFound = true
+			break
+		}
+	}
+	if !resetFound {
+		t.Fatal("expected a SetForwardingPipelineConfig call with empty P4DeviceConfig (ResetPipeline), none found")
+	}
+}
+
+// TestGetDeployedNetworkFunctions_AfterRestart verifies that after a driver restart,
+// when the switch already has a program loaded, EnsurePresent detects the existing
+// state and fast-paths to PhaseReady without re-deploying. GetDeployedNetworkFunctions
+// then correctly reflects the switch state.
+func TestGetDeployedNetworkFunctions_AfterRestart(t *testing.T) {
+	// Simulate the switch already having the program loaded.
+	mock := &mockP4Client{
+		getFwdPipelineFn: func(_ *p4v1.GetForwardingPipelineConfigRequest) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+			return &p4v1.GetForwardingPipelineConfigResponse{
+				Config: &p4v1.ForwardingPipelineConfig{
+					P4DeviceConfig: testP4Bytes,
+				},
+			}, nil
+		},
+	}
+
+	// Fresh manager — simulates driver restart (empty ops/programs maps).
+	mgr := newTestManagerWith(mock, &mockP4TargetManager{})
+	nf := newTestNF("test-nf", "test-ns")
+
+	handle := mgr.EnsurePresent(context.Background(), nf)
+	waitDone(t, handle)
+
+	if handle.Status().Phase != PhaseReady {
+		t.Fatalf("expected PhaseReady after restart, got %s: %v", handle.Status().Phase, handle.Err())
+	}
+	if mock.setCallCount() != 0 {
+		t.Fatalf("expected no SetForwardingPipelineConfig calls (program already loaded), got %d", mock.setCallCount())
+	}
+
+	deployed, err := mgr.GetDeployedNetworkFunctions(context.Background())
+	if err != nil {
+		t.Fatalf("GetDeployedNetworkFunctions: %v", err)
+	}
+	want := []client.ObjectKey{{Name: "test-nf", Namespace: "test-ns"}}
+	if len(deployed) != 1 || deployed[0] != want[0] {
+		t.Fatalf("expected %v, got %v", want, deployed)
+	}
+}

--- a/targets/bmv2/managers/nf/nf_mgr_types.go
+++ b/targets/bmv2/managers/nf/nf_mgr_types.go
@@ -103,7 +103,12 @@ func (h *deploymentHandle) Done() <-chan struct{} {
 
 func (h *deploymentHandle) Cancel() error {
 	h.cancel()
-	h.transition(PhaseCanceled, "deployment canceled", context.Canceled)
+	h.mu.RLock()
+	terminal := isTerminal(h.status.Phase)
+	h.mu.RUnlock()
+	if !terminal {
+		h.transition(PhaseCanceled, "deployment canceled", context.Canceled)
+	}
 	return nil
 }
 

--- a/targets/bmv2/managers/nf/nf_mgr_types.go
+++ b/targets/bmv2/managers/nf/nf_mgr_types.go
@@ -103,17 +103,16 @@ func (h *deploymentHandle) Done() <-chan struct{} {
 
 func (h *deploymentHandle) Cancel() error {
 	h.cancel()
-	h.mu.RLock()
-	terminal := isTerminal(h.status.Phase)
-	h.mu.RUnlock()
-	if !terminal {
-		h.transition(PhaseCanceled, "deployment canceled", context.Canceled)
-	}
+	h.transition(PhaseCanceled, "deployment canceled", context.Canceled)
 	return nil
 }
 
 func (h *deploymentHandle) transition(phase Phase, msg string, err error) {
 	h.mu.Lock()
+	if isTerminal(h.status.Phase) {
+		h.mu.Unlock()
+		return
+	}
 	h.status = DeploymentStatus{
 		Phase:   phase,
 		Message: msg,
@@ -129,14 +128,11 @@ func (h *deploymentHandle) transition(phase Phase, msg string, err error) {
 }
 
 func (h *deploymentHandle) emitEvent(phase Phase, msg string, err error) {
-	evt := DeploymentEvent{
-		Phase:   phase,
-		Message: msg,
-		Err:     err,
-	}
-
+	// recover guards against the narrow race where finish() closes h.events
+	// between the terminal check in transition() and this send.
+	defer func() { recover() }()
 	select {
-	case h.events <- evt:
+	case h.events <- DeploymentEvent{Phase: phase, Message: msg, Err: err}:
 	default:
 		// Drop if buffer full (critical: never block manager)
 	}


### PR DESCRIPTION
- Idempotent NF deploy: Skip `SetForwardingPipelineConfig` if switch already has identical config, making driver restarts safe
- Fix `Cancel()` panic by checking `isTerminal` before transitioning to avoid sending on closed channel
- Change `--p4target-name` default in `cmd/main.go` from bmv2-switch to bmv2-target to match CRD names
- Added NF lifecycle tests to cover deployment, deletion, and restart scenarios